### PR TITLE
能够正确的解析表数组 Parses table arrays correctly

### DIFF
--- a/control.gd
+++ b/control.gd
@@ -14,7 +14,8 @@ func _ready() -> void:
 	rtl.text += "BEGIN TIME > " + time + "\n\n"
 	
 	#test( "res://toml_file/test_all.toml" )
-	test( "res://toml_file/test.toml" )
+	#test( "res://toml_file/test.toml" )
+	test( "res://toml_file/list_array.toml" )
 	
 	time = Time.get_datetime_string_from_datetime_dict( Time.get_datetime_dict_from_system(), true )
 	

--- a/toml_file/list_array.toml
+++ b/toml_file/list_array.toml
@@ -1,0 +1,15 @@
+
+[[bin]]
+key1 = 0
+key2 = 1
+"key 2" = 2
+
+[[bin]]
+key1 = 1
+key2 = 2
+key3 = 3
+#key1 = 2
+
+#[list]
+#a.b.c = 0
+#a.b.e = 1


### PR DESCRIPTION
现在已经可以正确解析表数组了
You are now ready to parse the table array correctly

```
[[bin]]
key = 0
key1 = 1

[[bin]]
key = 3
key1 = 44
```

得到
get

```
{
    "bin": [
        {
            "key": 0,
           "key1": 1
        },
       {
            "key": 3,
           "key1":44
       }
    ]
}
```
